### PR TITLE
fixed bug when trying to read a task file and no permission

### DIFF
--- a/lib/App/MtAws/FileCreateJob.pm
+++ b/lib/App/MtAws/FileCreateJob.pm
@@ -27,7 +27,7 @@ use base qw/App::MtAws::Job/;
 use App::MtAws::FileUploadJob;
 use File::stat;
 use Time::localtime;
-
+use Carp;
 
 sub new
 {
@@ -52,7 +52,7 @@ sub get_task
 		my $filesize = -s $self->{filename};
 		$self->{mtime} = stat($self->{filename})->mtime; # TODO: how could we assure file not modified when uploading btw?
 		die "With current partsize=$self->{partsize} we will exceed 10000 parts limit for the file $self->{filename} (filesize $filesize)" if ($filesize / $self->{partsize} > 10000);
-	    open my $fh, "<$self->{filename}";
+	    open my $fh, "<$self->{filename}" or confess "ERROR: unable to open task file $self->{filename} for reading: $!";
 	    binmode $fh;
 	    $self->{fh} = $fh;
 		return ("ok", App::MtAws::Task->new(id => "create_upload",action=>"create_upload", data => { partsize => $self->{partsize}, relfilename => $self->{relfilename}, mtime => $self->{mtime} } ));


### PR DESCRIPTION
Hello,

I had a bug when trying to backup files readable by root only, took me a little time to figure it out, so I wrote a little fix.
Moreover, none of your system calls are checked, which is evil ;-)
You could use autodie in the meantime.

Thanks for your work
