### PR TITLE
add rasbian "seo"

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Can be installed/updated via custom repository
 
 6. install/update `LWP::UserAgent` and `LWP::Protocol::https` using [cpanm]
 
-##### Debian 7 (Wheezy)
+##### Debian 7 (Wheezy), including rasbian for Raspberry Pi
 
 Can be installed/updated via custom repository
 


### PR DESCRIPTION
I know there are occasional questions about "can this be installed on Raspberry Pi?"

Part of this is inexperience linuxers, part of it is the ARM core that means some packages don't work well.

The Wheezy install works properly, so I just added some "SEO" to highlight it.
