### PR TITLE
Add support for different description types

### DIFF
--- a/lib/App/MtAws/MetaData.pm
+++ b/lib/App/MtAws/MetaData.pm
@@ -114,6 +114,9 @@ sub meta_decode
 	return unless defined $str; # protect from undef $str
 
 	my ($marker, $b64) = _split_meta($str);
+
+	defined $b64 or return $str;
+
 	return unless defined $marker;
 	if ($marker eq 'mt1') {
 		return _decode_filename_and_mtime(_decode_json(_decode_utf8(_decode_b64($b64))));

--- a/lib/App/MtAws/MetaData.pm
+++ b/lib/App/MtAws/MetaData.pm
@@ -114,10 +114,7 @@ sub meta_decode
 	return unless defined $str; # protect from undef $str
 
 	my ($marker, $b64) = _split_meta($str);
-
-	defined $b64 or return $str;
-
-	return unless defined $marker;
+	return $str unless defined $marker;
 	if ($marker eq 'mt1') {
 		return _decode_filename_and_mtime(_decode_json(_decode_utf8(_decode_b64($b64))));
 	} elsif ($marker eq 'mt2') {


### PR DESCRIPTION
Hi,

mt-aws-glacier tries to decode each archive description, but if you have upload archives using different tools it's broke journal readability.

So, this small patch allow to have different type of descriptions and to fallback to the original description if it's not like an encoded by mt-aws-glacier.
