### PR TITLE
Ignore SIGPIPE in child worker

### DIFF
--- a/lib/App/MtAws/ChildWorker.pm
+++ b/lib/App/MtAws/ChildWorker.pm
@@ -48,6 +48,9 @@ sub process
 {
 	my ($self) = @_;
 
+	# Ignore SIGPIPE.
+	$SIG{'PIPE'} = 'IGNORE';
+
 	my $tochild = $self->{tochild};
 	my $fromchild = $self->{fromchild};
 	while (1) {


### PR DESCRIPTION
Without this PR, the child worker process will simply exit on SIGPIPE (e.g. when the TCP connection with the remote server breaks) and the parent will report something like this:
```
EXIT on SIGCHLD (signal 13, exit_code 0)
```

And then just terminate.