### PR TITLE
AWS sending back 400 Bad Request HTTP responses that work upon retry.…

### DIFF
--- a/lib/App/MtAws/GlacierRequest.pm
+++ b/lib/App/MtAws/GlacierRequest.pm
@@ -543,6 +543,10 @@ sub perform_lwp
 			print "PID $$ HTTP ".$resp->code." This might be normal. Will retry ($dt seconds spent for request)\n";
 			$self->{last_retry_reason} = $resp->code;
 			throttle($i);
+		} elsif ($resp->code =~ /^400$/) {
+			print "PID $$ HTTP ".$resp->code." Unexpected 400 Bad Request response received. Will retry ($dt seconds spent for request)\n";
+			$self->{last_retry_reason} = $resp->code;
+			throttle($i);
 		} elsif (defined($resp->header('X-Died')) && (get_exception($resp->header('X-Died')))) {
 			die $resp->header('X-Died'); # propogate our own exceptions
 		} elsif (defined($resp->header('X-Died')) && length($resp->header('X-Died'))) {
@@ -569,7 +573,7 @@ sub perform_lwp
 				return $resp;
 			}
 		} else {
-			if ($resp->code =~ /^40[03]$/) {
+			if ($resp->code =~ /^403$/) {
 				if ($resp->content_type && $resp->content_type eq 'application/json') {
 					my $json = JSON::XS->new->allow_nonref;
 					my $scalar = eval { $json->decode( $resp->content ); }; # we assume content always in utf8


### PR DESCRIPTION
… Issue appears to be on server side, but retrying works around issue for now.

Workaround for #125 

I agree that AWS should ideally address or at the very least explain why a 400 is being returned. But I needed to work around the issue for now and retry the upload part and figure I'd share even if it ultimately doesn't belong in the mainline release.